### PR TITLE
refactor(package): add es5 module build config

### DIFF
--- a/config/grunt/aliases.js
+++ b/config/grunt/aliases.js
@@ -11,7 +11,8 @@ module.exports = {
         'webpack',
         'replace:worker',
         'sh:build-es2018',
-        'sh:build-es5'
+        'sh:build-es5-bundle',
+        'sh:build-es5-module'
     ],
     lint: [
         'sh:lint-config',

--- a/config/grunt/sh.js
+++ b/config/grunt/sh.js
@@ -6,8 +6,11 @@ module.exports = (grunt) => {
         'build-es2018': {
             cmd: 'tsc -p src/tsconfig.json'
         },
-        'build-es5': {
+        'build-es5-bundle': {
             cmd: 'rollup -c config/rollup/bundle.js'
+        },
+        'build-es5-module': {
+            cmd: 'rollup -c config/rollup/module.js'
         },
         'lint-config': {
             cmd: `eslint --config config/eslint/config.json ${ (fix) ? '--fix ' : '' }--report-unused-disable-directives *.js config/**/*.js`

--- a/config/rollup/module.js
+++ b/config/rollup/module.js
@@ -1,0 +1,68 @@
+import babel from 'rollup-plugin-babel';
+import { fs } from 'memfs';
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import replace from 'rollup-plugin-replace';
+import webpack from 'webpack';
+import webpackConfig from '../webpack/config';
+
+const workerFile = readFileSync('src/worker/worker.ts', 'utf-8');
+const result = /export\sconst\sworker\s=\s`(?<workerString>.*)`;/g.exec(workerFile);
+
+if (result === null) {
+    throw new Error('The worker file could not be parsed.');
+}
+
+const workerString = result.groups.workerString;
+
+export default new Promise((resolve, reject) => { // eslint-disable-line import/no-default-export
+    const compiler = webpack(webpackConfig);
+
+    compiler.outputFileSystem = { ...fs, join };
+    compiler.run((err, stats) => {
+        if (stats.hasErrors() || stats.hasWarnings()) {
+            reject(new Error(stats.toString({ errorDetails: true, warnings: true })));
+        } else {
+            const transpiledWorkerString = fs
+                .readFileSync('/worker.js', 'utf-8')
+                .replace(/\\/g, '\\\\')
+                .replace(/\${/g, '\\${');
+
+            resolve({
+                input: 'build/es2018/module.js',
+                output: {
+                    file: 'build/es5/module.js',
+                    format: 'esm',
+                    name: 'workerTimers'
+                },
+                plugins: [
+                    replace({
+                        delimiters: [ '`', '`' ],
+                        include: 'build/es2018/worker/worker.js',
+                        values: {
+                            // V8 does only accept substrings with a maximum length of 32767 characters. Otherwise it throws a SyntaxError.
+                            [ workerString.slice(0, 32767) ]: `\`${ transpiledWorkerString }\``,
+                            [ workerString.slice(32767) ]: ''
+                        }
+                    }),
+                    babel({
+                        exclude: 'node_modules/**',
+                        plugins: [
+                            '@babel/plugin-external-helpers',
+                            '@babel/plugin-transform-runtime'
+                        ],
+                        presets: [
+                            [
+                                '@babel/preset-env',
+                                {
+                                    modules: false
+                                }
+                            ]
+                        ],
+                        runtimeHelpers: true
+                    })
+                ]
+            });
+        }
+    });
+});

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   ],
   "license": "MIT",
   "main": "build/es5/bundle.js",
-  "module": "build/es2018/module.js",
+  "module": "build/es5/module.js",
   "name": "worker-timers",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds the `browser` field to `package.json` to prioritize the es5 build when using webpack with `web` target.

See related webpack issue: https://github.com/webpack/webpack/issues/5756